### PR TITLE
Do not produce notice/warning when consuming from multiple transports…

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -535,7 +535,7 @@ class Connection
     public function queue(string $queueName): \AMQPQueue
     {
         if (!isset($this->amqpQueues[$queueName])) {
-            $queueConfig = $this->queuesOptions[$queueName];
+            $queueConfig = $this->queuesOptions[$queueName] ?? [];
 
             $amqpQueue = $this->amqpFactory->createQueue($this->channel());
             $amqpQueue->setName($queueName);


### PR DESCRIPTION
… and explicitly listed queues

These queues might not be present on each consumed transport.